### PR TITLE
Update token reference in deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     env:
-      VITE_BETTERSTACK_TOKEN: ${{ env.VITE_BETTERSTACK_TOKEN }}
+      VITE_BETTERSTACK_TOKEN: ${{ secrets.VITE_BETTERSTACK_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Changed the token reference within the Github actions deployment workflow to use secrets instead of environment variables. This enhances security as sensitive data is not exposed in the environment.